### PR TITLE
Add reset param to create pull request step

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -87,3 +87,4 @@ jobs:
         base: main
         title: 'Release v${{ steps.bump-version.outputs.new_version }}'
         body-path: changelog.txt
+        reset: false


### PR DESCRIPTION
# Background

Start release action fails with 

```
/usr/bin/git checkout --progress release/v1.0.0 --
Switched to branch 'release/v1.0.0'
/usr/bin/git reset --hard origin/release/v1.0.0
fatal: ambiguous argument 'origin/release/v1.0.0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Error: The process '/usr/bin/git' failed with exit code 128
```

# Solution

The `peter-evans/create-pull-request` action is trying to reset the newly created release branch to the origin/release/v1.0.0 branch, which doesn't exist yet since it's a new branch.

To fix this, we can disable the reset behavior of the peter-evans/create-pull-request action by setting the reset parameter to false. This will prevent the action from trying to reset the branch to a non-existent remote branch.

# Main changes

- Add flag `reset: false` in create pull request action.

# Additional changes


# Readyness checks

- [x] Code is clean
- [x] No commented code
- [x] Test cases added if required
- [x] Passing build
