### PR TITLE
Fix start release script

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -68,6 +68,7 @@ jobs:
         mv CHANGELOG.md.tmp CHANGELOG.md
 
     - name: Create Pull Request
+      id: create-pull-request
       uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -77,3 +78,10 @@ jobs:
         body-path: changelog.txt
         reviewers: acwilan
         commit-message: 'chore: prepare release v${{ steps.bump-version.outputs.new_version }}'
+
+    - name: Add comment
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        issue-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
+        body: Remember to change the target branch to 'main'
+        reactions: +1, rocket

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -74,6 +74,13 @@ jobs:
         cat CHANGELOG.md >> CHANGELOG.md.tmp
         mv CHANGELOG.md.tmp CHANGELOG.md
 
+    - name: Push release branch
+      run: |
+        git add .
+        git commit -m "chore: prepare release v${{ steps.bump-version.outputs.new_version }}"
+        git push origin ${{ steps.create-branch.outputs.release_branch }}
+  
+
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6
       with:
@@ -83,4 +90,3 @@ jobs:
         title: 'Release v${{ steps.bump-version.outputs.new_version }}'
         body-path: changelog.txt
         reviewers: acwilan
-        commit-message: 'chore: prepare release v${{ steps.bump-version.outputs.new_version }}'

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -58,13 +58,6 @@ jobs:
           new_version=$(node -p "require('./ui/package.json').version")
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
   
-    - name: Create release branch
-      id: create-branch
-      run: |
-          release_branch="release/v${{ steps.bump-version.outputs.new_version }}"
-          git checkout -b $release_branch
-          echo "release_branch=$release_branch" >> $GITHUB_OUTPUT
-  
     - name: Generate changelog
       id: generate-changelog
       run: |
@@ -74,19 +67,13 @@ jobs:
         cat CHANGELOG.md >> CHANGELOG.md.tmp
         mv CHANGELOG.md.tmp CHANGELOG.md
 
-    - name: Push release branch
-      run: |
-        git add .
-        git commit -m "chore: prepare release v${{ steps.bump-version.outputs.new_version }}"
-        git push origin ${{ steps.create-branch.outputs.release_branch }}
-  
-
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ steps.create-branch.outputs.release_branch }}
-        base: main
+        branch: release/v${{ steps.bump-version.outputs.new_version }}
+        base: develop
         title: 'Release v${{ steps.bump-version.outputs.new_version }}'
         body-path: changelog.txt
         reviewers: acwilan
+        commit-message: 'chore: prepare release v${{ steps.bump-version.outputs.new_version }}'

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -80,11 +80,12 @@ jobs:
         git commit -m "docs: update changelog for v${{ steps.bump-version.outputs.new_version }}"
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ steps.create-branch.outputs.release_branch }}
         base: main
         title: 'Release v${{ steps.bump-version.outputs.new_version }}'
         body-path: changelog.txt
+        reviewers: acwilan
         reset: false

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -44,6 +44,7 @@ jobs:
       env:
         BUMP_TYPE: ${{ github.event.inputs.bumpType }}
       run: |
+          echo "Bump type is '$BUMP_TYPE'"
           if [ "$BUMP_TYPE" == "major" ]; then
             yarn --cwd ./ui version --major --no-git-tag-version
             yarn version --major --no-git-tag-version
@@ -56,7 +57,6 @@ jobs:
           fi
           new_version=$(node -p "require('./ui/package.json').version")
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
-          git commit -am "chore: bump release version to $new_version"
   
     - name: Create release branch
       id: create-branch
@@ -69,15 +69,10 @@ jobs:
       id: generate-changelog
       run: |
         npx conventional-changelog-cli --output-unreleased --preset angular > changelog.txt
-
-    - name: Update changelog
-      run: |
         cat changelog.txt >> CHANGELOG.md
         echo "## Previous Releases" >> CHANGELOG.md
         cat CHANGELOG.md >> CHANGELOG.md.tmp
         mv CHANGELOG.md.tmp CHANGELOG.md
-        git add CHANGELOG.md
-        git commit -m "docs: update changelog for v${{ steps.bump-version.outputs.new_version }}"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6
@@ -88,4 +83,4 @@ jobs:
         title: 'Release v${{ steps.bump-version.outputs.new_version }}'
         body-path: changelog.txt
         reviewers: acwilan
-        reset: false
+        commit-message: 'chore: prepare release v${{ steps.bump-version.outputs.new_version }}'

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -83,5 +83,5 @@ jobs:
       uses: peter-evans/create-or-update-comment@v4
       with:
         issue-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
-        body: Remember to change the target branch to 'main'
+        body: Remember to change the target branch to `main` when merging this PR.
         reactions: +1, rocket


### PR DESCRIPTION
# Background

Start release kept failing with reset command.

# Solution

Let the plugin handle the commit and push. Also change target branch to develop.

# Main changes

- Update `start-release.yml` script

# Additional changes


# Readyness checks

- [x] Code is clean
- [x] No commented code
- [x] Test cases added if required
- [x] Passing build
