### PR TITLE
Reinvent top and left menu

### DIFF
--- a/.github/workflows/scripts/generateConfigFile.sh
+++ b/.github/workflows/scripts/generateConfigFile.sh
@@ -5,17 +5,36 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+if [ -z "$BEAM_APPS" ]; then
+    echo "Environment variable BEAM_APPS is not set."
+    exit 1
+fi
+
+if [ -z "$BEAM_AUTH_TOKEN" ]; then
+    echo "Environment variable BEAM_AUTH_TOKEN is not set."
+    exit 1
+fi
+
 OUTPUT_FILE=$1
 
 echo "export const config = {" > $OUTPUT_FILE
-echo "    models: [" >> $OUTPUT_FILE
-echo "        {" >> $OUTPUT_FILE
-echo "            id: \"1\"," >> $OUTPUT_FILE
-echo "            name: \"Beam Model\"," >> $OUTPUT_FILE
-echo "            beamId: '${BEAM_APP_ID}'" >> $OUTPUT_FILE
-echo "        }" >> $OUTPUT_FILE
-echo "    ]," >> $OUTPUT_FILE
-echo "    beam: {" >> $OUTPUT_FILE
-echo "        authToken: '${BEAM_AUTH_TOKEN}'" >> $OUTPUT_FILE
-echo "    }" >> $OUTPUT_FILE
+echo "  beam: {" >> $OUTPUT_FILE
+echo "    models: {" >> $OUTPUT_FILE
+
+IFS=',' read -ra APPS <<< "$BEAM_APPS"
+for APP in "${APPS[@]}"; do
+    IFS='|' read -ra PAIR <<< "$APP"
+    ID="${PAIR[0]}"
+    NAME="${PAIR[1]}"
+    echo "        \"$ID\": {" >> $OUTPUT_FILE
+    echo "            name: \"$NAME\"" >> $OUTPUT_FILE
+    echo "        }," >> $OUTPUT_FILE
+done
+
+# Remove the last comma to avoid syntax error in JSON
+sed -i '$ s/,$//' $OUTPUT_FILE
+
+echo "    }," >> $OUTPUT_FILE
+echo "    authToken: '$BEAM_AUTH_TOKEN'" >> $OUTPUT_FILE
+echo "  }" >> $OUTPUT_FILE
 echo "};" >> $OUTPUT_FILE

--- a/conf/sdConfig.sample.ts
+++ b/conf/sdConfig.sample.ts
@@ -1,22 +1,16 @@
 export const config = {
-    models: [
-        {
-            id: "1",
-            name: "Stable Diffusion 1.5",
-            beamId: 'beamApp1Id'
-        },
-        {
-            id: "2",
-            name: "Stable Diffusion 2.0",
-            beamId: 'beamApp2Id'
-        },
-        {
-            id: "3",
-            name: "Stable Diffusion XL",
-            beamId: 'beamApp3Id'
-        }
-    ],
     beam: {
+        models: {
+            "model1": {
+                name: "Model 1"
+            },
+            "model2": {
+                name: "Model 2"
+            },
+            "model3": {
+                name: "Model 3"
+            }
+        },
         authToken: 'beamAuthToken'
     }
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "engines": {
     "node": "18.x",
-    "yarn": "1.22.22"
+    "yarn": "1.22.x"
   },
   "repository": {
     "type": "git",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   },
   "engines": {
     "node": "18.x",
-    "yarn": "1.22.22"
+    "yarn": "1.22.x"
   },
   "dependencies": {
     "@babel/core": "^7.24.6",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Link, Routes, Route } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Link, Routes, Route, useLocation } from 'react-router-dom';
 import { Navbar, Container } from 'react-bootstrap';
 import Navigation from './components/Navigation';
 import Sidebar from './components/Sidebar';
@@ -10,7 +10,16 @@ import Txt2Img from './components/Txt2Img';
 const Img2Img = () => <h2>Image to Image (Img2Img)</h2>;
 const Txt2Vid = () => <h2>Text to Video (Txt2Vid)</h2>;
 
+// A custom hook to extract the first path segment
+const useFirstPathSegment = () => {
+  const location = useLocation();
+  const pathSegments = location.pathname.split('/').filter(Boolean);
+  return pathSegments[0] || 'beam';
+};
+
 const App: React.FC<{ theme: string }> = ({ theme }) => {
+  const firstPathSegment = useFirstPathSegment();
+
   return (
     <div>
       <Navbar bg={theme} variant={theme} expand="lg">
@@ -22,13 +31,14 @@ const App: React.FC<{ theme: string }> = ({ theme }) => {
       </Navbar>
       <Container fluid className="app-container">
         <div className="d-flex">
-          <Sidebar />
+          <Sidebar pathSegment={firstPathSegment} />
           <div className="content-container">
             <Routes>
-              <Route path='/' element={<Home />} />
-              <Route path='/txt2img' element={<Txt2Img />} />
-              <Route path="/img2img" element={<Img2Img />} />
-              <Route path="/txt2vid" element={<Txt2Vid />} />
+              <Route path='/' element={<Home pathSegment='' />} />
+              <Route path={`/${firstPathSegment}`} element={<Home pathSegment={firstPathSegment} />} />
+              <Route path={`/${firstPathSegment}/img2img`} element={<Img2Img />} />
+              <Route path={`/${firstPathSegment}/txt2img`} element={<Txt2Img pathSegment={firstPathSegment} />} />
+              <Route path={`/${firstPathSegment}/txt2vid`} element={<Txt2Vid />} />
             </Routes>
           </div>
         </div>

--- a/ui/src/components/Home.tsx
+++ b/ui/src/components/Home.tsx
@@ -3,19 +3,25 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Card, Row, Col } from 'react-bootstrap';
 import './Home.css'; // Add custom CSS for clickable cards
+import { PathComponentProps } from '../types';
+import { camelCaseToSentence } from '../stringUtils';
 
-const Home = () => {
-  const features = [
-    { name: 'Text to image (Txt2Img)', path: '/txt2img' },
-    { name: 'Image to image (Img2Img)', path: '/img2img' },
-    { name: 'Text to video (Txt2Vid)', path: '/txt2vid' },
+const Home: React.FC<PathComponentProps> = ({ pathSegment }) => {
+  const features = pathSegment ? [
+    { name: 'Text to image (Txt2Img)', path: `/${pathSegment}/txt2img` },
+    { name: 'Image to image (Img2Img)', path: '' },
+    { name: 'Text to video (Txt2Vid)', path: '' },
+  ] : [
+    { name: 'Beam', path: '/beam' }
   ];
+
+  const title: string = camelCaseToSentence(pathSegment || 'welcomeToSdPlat');
 
   return (
     <>
-        <h2>Welcome</h2>
+        <h2>{title}</h2>
         <Row className="mt-4">
-        {features.map((feature, index) => (
+        {features.filter(feature => feature.path !== '').map((feature, index) => (
             <Col key={index} sm={12} md={4} className="mb-4">
             <Link to={feature.path} className="card-link">
                 <Card>

--- a/ui/src/components/Navigation.tsx
+++ b/ui/src/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { Nav, Navbar } from 'react-bootstrap';
+import { Nav, Navbar, NavbarText } from 'react-bootstrap';
 import './Navigation.css';
 
 const Navigation: React.FC = () => {
@@ -8,9 +8,9 @@ const Navigation: React.FC = () => {
       <Navbar.Collapse id="basic-navbar-nav">
         <Nav className="me-auto">
           <Nav.Link as={NavLink} to="/">Home</Nav.Link>
-          <Nav.Link as={NavLink} to="/txt2img">Text to image</Nav.Link>
-          <Nav.Link as={NavLink} to="/img2img">Image to image</Nav.Link>
-          <Nav.Link as={NavLink} to="/txt2vid">Text to video</Nav.Link>
+          <Nav.Link as={NavLink} to="/beam">Beam</Nav.Link>
+          <Nav.Link as={NavbarText}>Modelslab</Nav.Link>
+          <Nav.Link as={NavbarText}>Stability AI</Nav.Link>
         </Nav>
       </Navbar.Collapse>
   );

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { Button, Collapse, Nav } from 'react-bootstrap';
+import { Button, Collapse, Nav, NavbarText } from 'react-bootstrap';
 import './Sidebar.css';
+import { PathComponentProps } from '../types';
 
-const Sidebar: React.FC = () => {
+const Sidebar: React.FC<PathComponentProps> = ({ pathSegment }) => {
   const [open, setOpen] = useState(() => {
     const storedValue = localStorage.getItem('sidebarCollapsed');
     return storedValue ? JSON.parse(storedValue) : true;
@@ -30,10 +31,9 @@ const Sidebar: React.FC = () => {
       <Collapse in={open}>
         <div id="example-collapse">
           <Nav className="flex-column">
-            <Nav.Link href="#home">Home</Nav.Link>
-            <Nav.Link href="#about">About</Nav.Link>
-            <Nav.Link href="#services">Services</Nav.Link>
-            <Nav.Link href="#contact">Contact</Nav.Link>
+            <Nav.Link href={`/${pathSegment}/txt2Img`}>Text to image</Nav.Link>
+            <Nav.Link as={NavbarText}>Image to image</Nav.Link>
+            <Nav.Link as={NavbarText}>Text to video</Nav.Link>
           </Nav>
         </div>
       </Collapse>

--- a/ui/src/components/Txt2Img.tsx
+++ b/ui/src/components/Txt2Img.tsx
@@ -6,7 +6,11 @@ import OutputView from "./OutputView";
 import { PathComponentProps } from "../types";
 
 const { authToken, models } = config.beam;
-const sortedModels: ModelInfo[] = models.sort((a: ModelInfo, b: ModelInfo) => a.name.localeCompare(b.name));
+const sortedModels: ModelInfo[] = Object.entries(models)
+    .map(([id, model]) => ({
+        id,
+        name: model.name
+    })).sort((a: ModelInfo, b: ModelInfo) => a.name.localeCompare(b.name));
 const modelMap: { [id: string ]: ModelInfo} = sortedModels.reduce((map, model) => {
     map[model.id] = model;
     return map;

--- a/ui/src/components/Txt2Img.tsx
+++ b/ui/src/components/Txt2Img.tsx
@@ -3,15 +3,16 @@ import { FormComponent, FormData, ModelInfo } from "./FormComponent";
 import { BeamClient, Txt2ImgRequest } from "../api";
 import { config } from '../../../conf/sdConfig';
 import OutputView from "./OutputView";
+import { PathComponentProps } from "../types";
 
-const sortedModels: ModelInfo[] = config.models.sort((a: ModelInfo, b: ModelInfo) => a.name.localeCompare(b.name));
+const { authToken, models } = config.beam;
+const sortedModels: ModelInfo[] = models.sort((a: ModelInfo, b: ModelInfo) => a.name.localeCompare(b.name));
 const modelMap: { [id: string ]: ModelInfo} = sortedModels.reduce((map, model) => {
     map[model.id] = model;
     return map;
 }, {} as { [id: string]: ModelInfo });
-const authToken: string = config.beam.authToken;
 
-const Txt2Img: React.FC = () => {
+const Txt2Img: React.FC<PathComponentProps> = ({ pathSegment }) => {
     const [ imgUrl, setImgUrl ] = useState<string>('');
     const [ outputMessage, setOutputMessage ] = useState<string>('');
     const [ messageType, setMessageType ] = useState<'success' | 'danger' | 'info'>();

--- a/ui/src/stringUtils.ts
+++ b/ui/src/stringUtils.ts
@@ -1,0 +1,15 @@
+export function camelCaseToSentence(camelCase: string): string {
+    // Split camelCase string into words
+    const words = camelCase.replace(/([a-z])([A-Z])/g, '$1 $2').split(' ');
+
+    // Capitalize the first word and convert the rest to lowercase
+    const capitalizedWords = words.map((word, index) => {
+        if (index === 0) {
+            return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+        }
+        return word.toLowerCase();
+    });
+
+    // Join the words into a sentence
+    return capitalizedWords.join(' ');
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1,0 +1,3 @@
+export interface PathComponentProps {
+    pathSegment: string
+}

--- a/ui/test/App.test.tsx
+++ b/ui/test/App.test.tsx
@@ -44,6 +44,6 @@ test('renders Home component at the root path', () => {
   );
 
   // Check if the Home component is rendered
-  expect(screen.getByText(/Home/i)).toBeInTheDocument();
+  expect(screen.getByText(/Welcome to sd plat/i)).toBeInTheDocument();
   expect(screen.getByText(/Beam/i)).toBeInTheDocument();
 });

--- a/ui/test/App.test.tsx
+++ b/ui/test/App.test.tsx
@@ -13,7 +13,7 @@ test('renders welcome message', () => {
       <App theme="light" />
     </MemoryRouter>
   );
-  const linkElement = screen.getByText(/Welcome/i);
+  const linkElement = screen.getByText(/welcome to sd plat/i);
   expect(linkElement).toBeInTheDocument();
 });
 
@@ -21,30 +21,29 @@ test('navigates to Txt2Img page when the card is clicked', () => {
   render(
     <MemoryRouter initialEntries={['/']}>
       <Routes>
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<Home pathSegment='' />} />
         <Route path="/txt2img" element={<FormComponent models={mockModels} />} />
       </Routes>
     </MemoryRouter>
   );
 
-  // Click on the "Text to image (Txt2Img)" card
-  userEvent.click(screen.getByText(/Text to image \(Txt2Img\)/i));
+  // Click on the "Beam" card
+  userEvent.click(screen.getByText(/Beam/i));
 
   // Check if the FormComponent is rendered
-  expect(screen.getByText(/Text to image/i)).toBeInTheDocument();
+  expect(screen.getByText(/Beam/i)).toBeInTheDocument();
 });
 
 test('renders Home component at the root path', () => {
   render(
     <MemoryRouter initialEntries={['/']}>
       <Routes>
-        <Route path="/" element={<Home />} />
+        <Route path="/" element={<Home pathSegment='' />} />
       </Routes>
     </MemoryRouter>
   );
 
   // Check if the Home component is rendered
-  expect(screen.getByText(/text to image \(txt2img\)/i)).toBeInTheDocument();
-  expect(screen.getByText(/image to image \(img2img\)/i)).toBeInTheDocument();
-  expect(screen.getByText(/text to video \(txt2vid\)/i)).toBeInTheDocument();
+  expect(screen.getByText(/Home/i)).toBeInTheDocument();
+  expect(screen.getByText(/Beam/i)).toBeInTheDocument();
 });

--- a/ui/test/components/Sidebar.test.tsx
+++ b/ui/test/components/Sidebar.test.tsx
@@ -5,7 +5,7 @@ import Sidebar from '../../src/components/Sidebar';
 
 describe('Sidebar', () => {
   test('should toggle sidebar when button is clicked', () => {
-    const { getByRole } = render(<Sidebar />);
+    const { getByRole } = render(<Sidebar pathSegment='' />);
     const button = getByRole('button', { name: 'Toggle Sidebar' });
 
     fireEvent.click(button);
@@ -14,7 +14,7 @@ describe('Sidebar', () => {
   });
 
   test('should persist sidebar state to local storage', () => {
-    const { getByRole } = render(<Sidebar />);
+    const { getByRole } = render(<Sidebar pathSegment='' />);
     const button = getByRole('button', { name: 'Toggle Sidebar' });
     let storedValue = localStorage.getItem('sidebarCollapsed');
     const expectedValue = storedValue ? !JSON.parse(storedValue) : false;

--- a/ui/test/components/Txt2Img.test.tsx
+++ b/ui/test/components/Txt2Img.test.tsx
@@ -26,7 +26,11 @@ describe('Txt2Img Component', () => {
             expect.objectContaining({
                 submitHandler: expect.any(Function),
                 clearHandler: expect.any(Function),
-                models: models.sort((a, b) => a.name.localeCompare(b.name)),
+                models: Object.entries(models)
+                    .map(([id, model]) => ({
+                        id,
+                        name: model.name
+                    })).sort((a, b) => a.name.localeCompare(b.name)),
             }),
             {}
         );
@@ -43,7 +47,7 @@ describe('Txt2Img Component', () => {
         render(<Txt2Img pathSegment='' />);
 
         const submitHandler = (FormComponent as jest.Mock).mock.calls[0][0].submitHandler as (formData: FormData) => Promise<void>;
-        const formData: FormData = { prompt: 'test prompt', model: models[0].id, height: '', width: '', negativePrompt: '' };
+        const formData: FormData = { prompt: 'test prompt', model: Object.keys(models)[0], height: '', width: '', negativePrompt: '' };
 
         await act(async () => submitHandler(formData));
 
@@ -82,7 +86,7 @@ describe('Txt2Img Component', () => {
         render(<Txt2Img pathSegment='' />);
 
         const submitHandler = (FormComponent as jest.Mock).mock.calls[0][0].submitHandler as (formData: FormData) => Promise<void>;
-        const formData: FormData = { prompt: 'test prompt', model: models[0].id, height: '', width: '', negativePrompt: '' };
+        const formData: FormData = { prompt: 'test prompt', model: Object.keys(models)[0], height: '', width: '', negativePrompt: '' };
 
         await act(async () => submitHandler(formData));
 

--- a/ui/test/components/Txt2Img.test.tsx
+++ b/ui/test/components/Txt2Img.test.tsx
@@ -3,7 +3,6 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Txt2Img from '../../src/components/Txt2Img';
 import { FormComponent, FormData } from '../../src/components/FormComponent';
-import { BeamClient } from '../../src/api/beam/BeamClient';
 import { config } from '../../../conf/sdConfig';
 
 jest.mock('../../src/components/FormComponent', () => ({
@@ -11,6 +10,8 @@ jest.mock('../../src/components/FormComponent', () => ({
 }));
 
 const mockFetch = jest.fn();
+
+const { models } = config.beam;
 
 global.fetch = mockFetch;
 
@@ -20,12 +21,12 @@ describe('Txt2Img Component', () => {
     });
 
     test('renders FormComponent with correct props', () => {
-        render(<Txt2Img />);
+        render(<Txt2Img pathSegment='' />);
         expect(FormComponent).toHaveBeenCalledWith(
             expect.objectContaining({
                 submitHandler: expect.any(Function),
                 clearHandler: expect.any(Function),
-                models: config.models.sort((a, b) => a.name.localeCompare(b.name)),
+                models: models.sort((a, b) => a.name.localeCompare(b.name)),
             }),
             {}
         );
@@ -39,10 +40,10 @@ describe('Txt2Img Component', () => {
             json: async () => ({ status: 'COMPLETE', outputs: { './output.png': { url: 'https://example.com/image.jpg' } } })
         });
 
-        render(<Txt2Img />);
+        render(<Txt2Img pathSegment='' />);
 
         const submitHandler = (FormComponent as jest.Mock).mock.calls[0][0].submitHandler as (formData: FormData) => Promise<void>;
-        const formData: FormData = { prompt: 'test prompt', model: config.models[0].id, height: '', width: '', negativePrompt: '' };
+        const formData: FormData = { prompt: 'test prompt', model: models[0].id, height: '', width: '', negativePrompt: '' };
 
         await act(async () => submitHandler(formData));
 
@@ -78,10 +79,10 @@ describe('Txt2Img Component', () => {
             json: async () => ({ status: 'ERROR', message: 'test error' })
         });
 
-        render(<Txt2Img />);
+        render(<Txt2Img pathSegment='' />);
 
         const submitHandler = (FormComponent as jest.Mock).mock.calls[0][0].submitHandler as (formData: FormData) => Promise<void>;
-        const formData: FormData = { prompt: 'test prompt', model: config.models[0].id, height: '', width: '', negativePrompt: '' };
+        const formData: FormData = { prompt: 'test prompt', model: models[0].id, height: '', width: '', negativePrompt: '' };
 
         await act(async () => submitHandler(formData));
 
@@ -109,7 +110,7 @@ describe('Txt2Img Component', () => {
     });
 
     test('handles form clearing', () => {
-        render(<Txt2Img />);
+        render(<Txt2Img pathSegment='' />);
 
         const clearHandler = (FormComponent as jest.Mock).mock.calls[0][0].clearHandler as () => void;
 

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
       directory: path.join(__dirname, 'public'),
     },
     compress: true,
-    port: 9000,
+    port: 9001,
     historyApiFallback: true,
   }
 };


### PR DESCRIPTION
# Background

Current UI has generation options at the top, and the side bar unusable. As we're expanding APIs, we want the APIs to be at the top, and use the sidebar for generation options.

# Solution

Modify the top navigation bar to display APIs, and sidebar to display generation options.

# Main changes

- As said in solution.

# Additional changes

- Update tests

# Readyness checks

- [x] Code is clean
- [x] No commented code
- [x] Test cases added if required
- [x] Passing build

Closes #29 