### PR TITLE
Add beam api scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,15 @@ dist
 
 sdConfig.ts
 changelog.txt
+
+api/beam/img2vid/*
+!api/beam/img2vid/svd.py
+api/beam/txt2img/*
+!api/beam/txt2img/common.py
+!api/beam/txt2img/sd1.5.py
+!api/beam/txt2img/sd2.py
+!api/beam/txt2img/sdxl-turbo.py
+!api/beam/txt2img/sdxl.py
+api/beam/txt2vid/*
+!api/beam/txt2vid/common.py
+!api/beam/txt2vid/animatediff*.py

--- a/api/beam/img2vid/svd.py
+++ b/api/beam/img2vid/svd.py
@@ -1,0 +1,74 @@
+"""
+### Stable Video Diffusion on Beam ###
+
+**Deploy it as an API**
+
+beam deploy svd.5.py:generate_video
+"""
+from beam import App, Output, Volume, Runtime, Image
+import torch
+from diffusers import StableVideoDiffusionPipeline, AutoencoderKL, DiffusionPipeline
+from diffusers.utils import load_image, export_to_video
+
+cache_path = "./models"
+
+def load_models():
+    pipe = StableVideoDiffusionPipeline.from_pretrained(
+        "stabilityai/stable-video-diffusion-img2vid-xt",
+        torch_dtype=torch.float16,
+        cache_dir=cache_path,
+        variant="fp16",
+        use_safetensors=True
+    ).to("cuda")
+
+    return pipe
+
+app = App(
+        name="i2v-svd",
+        runtime=Runtime(
+            cpu=2,
+            memory="16Gi",
+            gpu="A10G",
+            image=Image(
+                python_version="python3.8",
+                python_packages=[
+                    "diffusers[torch]>=0.10",
+                    "transformers",
+                    "torch",
+                    "pillow",
+                    "accelerate",
+                    "safetensors",
+                    "xformers",
+                    "opencv-python",
+                ],
+            ),
+        ),
+        volumes=[
+            Volume(name="models", path="./models"),
+        ],
+    )
+
+@app.task_queue(
+    loader=load_models,
+    outputs=[Output(path="output.mp4")],
+    keep_warm_seconds=60,
+)
+def generate_video(**inputs):
+    # Grab inputs passed to the API
+    image_url = inputs["image_url"]
+
+    # Retrieve pre-loaded model from loader
+    pipe = inputs["context"]
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    generator = torch.manual_seed(42)
+    image = load_image(f"{image_url}")
+    image = image.resize((1024, 576))
+
+    with torch.inference_mode():
+        with torch.autocast("cuda"):
+            frames = pipe(image, 
+                          decode_chunk_size=2, 
+                          generator=generator).frames[0]
+
+    export_to_video(frames, "output.mp4", fps=7)

--- a/api/beam/txt2img/common.py
+++ b/api/beam/txt2img/common.py
@@ -1,0 +1,29 @@
+import re
+
+def extract_tokens(input_string):
+    tokens = re.findall(r'<lora:([^:]+):([0-9.]+)>', input_string)
+    print(f"Found {len(tokens)} tokens")
+    cleaned_string = re.sub(r'<lora:[^>]+>', '', input_string)
+    extracted_data = [{'name': token[0], 'scale': float(token[1])} for token in tokens]
+    return cleaned_string, extracted_data
+
+def handle_loras(extracted_data, pipe):
+    lora_names = []
+    if extracted_data:
+        lora_scales = []
+        for token in extracted_data:
+            lora_name = token['name']
+            print(f"Found lora with name {lora_name}")
+            lora_scale = token['scale']
+            pipe.load_lora_weights(
+                "./loras", 
+                weight_name=f"{lora_name}.safetensors", 
+                adapter_name=lora_name)
+            lora_names.append(lora_name)
+            lora_scales.append(lora_scale)
+        pipe.set_adapters(lora_names, lora_scales)
+    return lora_names
+
+def unload_loras(lora_names, pipe):
+    if lora_names:
+        pipe.delete_adapters(lora_names)

--- a/api/beam/txt2img/sd1.5.py
+++ b/api/beam/txt2img/sd1.5.py
@@ -1,0 +1,90 @@
+"""
+### Stable Diffusion 1.5 on Beam ###
+
+**Deploy it as an API**
+
+beam deploy sd1.5.py:generate_image
+"""
+from beam import App, Output, Volume, Runtime, Image
+import torch
+from diffusers import StableDiffusionPipeline
+from common import extract_tokens, handle_loras, unload_loras
+
+cache_path = "./models"
+
+def load_models():
+    pipe = StableDiffusionPipeline.from_pretrained(
+        "runwayml/stable-diffusion-v1-5",
+        torch_dtype=torch.float16,
+        cache_dir=cache_path,
+        variant="fp16",
+        safety_checker=None,
+        use_safetensors=True
+    ).to("cuda")
+
+    return pipe
+
+app = App(
+        name="t2i-sd1.5",
+        runtime=Runtime(
+            cpu=2,
+            memory="16Gi",
+            gpu="A10G",
+            image=Image(
+                python_version="python3.8",
+                python_packages=[
+                    "diffusers[torch]>=0.10",
+                    "transformers",
+                    "torch",
+                    "pillow",
+                    "accelerate",
+                    "safetensors",
+                    "xformers",
+                ],
+            ),
+        ),
+        volumes=[
+            Volume(name="models", path="./models"),
+            Volume(name="loras", path="./loras")
+        ],
+    )
+
+@app.task_queue(
+    loader=load_models,
+    outputs=[Output(path="output.png")],
+    keep_warm_seconds=60,
+)
+def generate_image(**inputs):
+    # Grab inputs passed to the API
+    prompt = inputs["prompt"]
+    cleaned_string, extracted_data = extract_tokens(prompt)
+
+    # Grab inputs passed to the API
+    negative_prompt = inputs.get("negative_prompt", "(deformed iris, deformed pupils), text, worst quality, low quality, jpeg artifacts, duplicate, morbid, mutilated, (extra fingers), (mutated hands), poorly drawn hands, poorly drawn face, mutation, deformed, blurry, dehydrated, bad anatomy, bad proportions, extra limbs, cloned face, disfigured, gross proportions, malformed limbs, missing arms, missing legs, extra arms, extra legs, (fused fingers), (too many fingers), long neck, camera")
+    height = int(inputs.get("height", "512"))
+    width = int(inputs.get("width", "512"))
+    steps = int(inputs.get("steps", "50"))
+    scale = float(inputs.get("guidance_scale", "7.5"))
+    
+    # Retrieve pre-loaded model from loader
+    pipe = inputs["context"]
+
+    lora_names = handle_loras(extracted_data=extracted_data, pipe=pipe)
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    with torch.inference_mode():
+        with torch.autocast("cuda"):
+            image = pipe(
+                cleaned_string, 
+                num_inference_steps=steps, 
+                guidance_scale=scale,
+                negative_prompt=negative_prompt,
+                height=height,
+                width=width
+            ).images[0]
+
+    unload_loras(lora_names, pipe)
+
+    print(f"Saved Image: {image}")
+    image.save("output.png")

--- a/api/beam/txt2img/sd2.py
+++ b/api/beam/txt2img/sd2.py
@@ -1,0 +1,117 @@
+"""
+### Stable Diffusion 2 on Beam ###
+
+**Deploy it as an API**
+
+beam deploy sd2.py:generate_image
+"""
+from beam import App, Output, Volume, Runtime, Image
+import torch
+from diffusers import DiffusionPipeline, AutoencoderKL, StableDiffusionLatentUpscalePipeline, StableDiffusionImg2ImgPipeline
+from common import extract_tokens, handle_loras, unload_loras
+
+cache_path = "./models"
+
+def load_models():
+    vae = AutoencoderKL.from_pretrained(
+        "stabilityai/sd-vae-ft-mse"
+    )
+    pipe = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-2-1",
+        torch_dtype=torch.float16,
+        cache_dir=cache_path,
+        variant="fp16",
+        vae=vae,
+        safety_checker=None,
+        use_safetensors=True
+    )
+    upscaler = StableDiffusionLatentUpscalePipeline.from_pretrained(
+        "stabilityai/sd-x2-latent-upscaler", 
+        torch_dtype=torch.float16
+    )
+    img2img = StableDiffusionImg2ImgPipeline(**pipe.components)
+
+    return pipe.to("cuda"), upscaler.to("cuda"), img2img.to("cuda")
+
+app = App(
+        name="t2i-sd2",
+        runtime=Runtime(
+            cpu=2,
+            memory="16Gi",
+            gpu="A10G",
+            image=Image(
+                python_version="python3.8",
+                python_packages=[
+                    "diffusers[torch]>=0.10",
+                    "transformers",
+                    "torch",
+                    "pillow",
+                    "accelerate",
+                    "safetensors",
+                    "xformers",
+                    "scipy",
+                    "ftfy"
+                ],
+            ),
+        ),
+        volumes=[
+            Volume(name="models", path="./models"),
+            Volume(name="loras", path="./loras")
+        ],
+    )
+
+@app.task_queue(
+    loader=load_models,
+    outputs=[Output(path="output.png")],
+    keep_warm_seconds=60,
+)
+def generate_image(**inputs):
+    # Grab inputs passed to the API
+    prompt = inputs["prompt"]
+    cleaned_string, extracted_data = extract_tokens(prompt)
+
+    # Grab inputs passed to the API
+    negative_prompt = inputs.get("negative_prompt", "")
+    height = int(inputs.get("height", "768"))
+    width = int(inputs.get("width", "768"))
+    steps = int(inputs.get("steps", "50"))
+    scale = float(inputs.get("guidance_scale", "7.5"))
+    
+    # Retrieve pre-loaded model from loader
+    pipe, upscaler, img2img = inputs["context"]
+
+    lora_names = handle_loras(extracted_data=extracted_data, pipe=pipe)
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    with torch.inference_mode():
+        with torch.autocast("cuda"):
+            image = pipe(
+                cleaned_string, 
+                num_inference_steps=steps, 
+                guidance_scale=scale,
+                negative_prompt=negative_prompt,
+                height=height,
+                width=width,
+                output_type="latent"
+            ).images[0]
+
+    image = upscaler(
+        prompt,
+        image=image,
+        num_inference_steps=steps,
+        guidance_scale=scale,
+        output_type="latent"
+    ).images[0]
+
+    image = img2img(prompt, 
+                    image=image,
+                    num_inference_steps=steps, 
+                    strength=0.5, 
+                    output_type="pt"
+                    )
+
+    unload_loras(lora_names, pipe)
+
+    print(f"Saved Image: {image}")
+    image.save("output.png")

--- a/api/beam/txt2img/sdxl-turbo.py
+++ b/api/beam/txt2img/sdxl-turbo.py
@@ -1,0 +1,87 @@
+"""
+### Stable Diffusion XL Turbo on Beam ###
+
+**Deploy it as an API**
+
+beam deploy sdxl-turbo.py:generate_image
+"""
+from beam import App, Output, Volume, Runtime, Image
+import torch
+from diffusers import AutoPipelineForText2Image
+from common import extract_tokens, handle_loras, unload_loras
+
+cache_path = "./models"
+
+def load_models():
+    pipe = AutoPipelineForText2Image.from_pretrained(
+        "stabilityai/sdxl-turbo",
+        torch_dtype=torch.float32,
+        cache_dir=cache_path,
+        variant="fp16",
+        use_safetensors=True,
+    )
+
+    return pipe
+
+app = App(
+        name="t2i-sdxl-turbo",
+        runtime=Runtime(
+            cpu=2,
+            memory="16Gi",
+            gpu="A10G",
+            image=Image(
+                python_version="python3.8",
+                python_packages=[
+                    "diffusers[torch]>=0.10",
+                    "transformers",
+                    "torch",
+                    "pillow",
+                    "accelerate",
+                    "safetensors",
+                    "xformers",
+                    "accelerate"
+                ],
+            ),
+        ),
+        volumes=[
+            Volume(name="models", path="./models"),
+            Volume(name="loras", path="./loras")
+        ],
+    )
+
+@app.task_queue(
+    loader=load_models,
+    outputs=[Output(path="output.png")],
+    keep_warm_seconds=60,
+)
+def generate_image(**inputs):
+    # Grab inputs passed to the API
+    prompt = inputs["prompt"]
+    cleaned_string, extracted_data = extract_tokens(prompt)
+
+    # Grab inputs passed to the API
+    negative_prompt = inputs.get("negative_prompt", "")
+    steps = int(inputs.get("steps", "4"))
+    
+    # Retrieve pre-loaded model from loader
+    pipe = inputs["context"]
+
+    lora_names = handle_loras(extracted_data=extracted_data, pipe=pipe)
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    with torch.inference_mode():
+        with torch.autocast("cuda"):
+            image = pipe(
+                prompt=cleaned_string, 
+                num_inference_steps=steps, 
+                guidance_scale=0.0,
+                negative_prompt=negative_prompt,
+                height=512,
+                width=512
+            ).images[0]
+
+    unload_loras(lora_names, pipe)
+
+    print(f"Saved Image: {image}")
+    image.save("output.png")

--- a/api/beam/txt2img/sdxl.py
+++ b/api/beam/txt2img/sdxl.py
@@ -1,0 +1,127 @@
+"""
+### Stable Diffusion XL on Beam ###
+
+**Deploy it as an API**
+
+beam deploy sdxl.py:generate_image
+"""
+from beam import App, Output, Volume, Runtime, Image
+import torch
+from diffusers import DiffusionPipeline, AutoencoderKL
+from common import extract_tokens, handle_loras, unload_loras
+
+cache_path = "./models"
+
+def load_models():
+    vae = AutoencoderKL.from_pretrained(
+        "madebyollin/sdxl-vae-fp16-fix", 
+        torch_dtype=torch.float16
+    ).to("cuda")
+
+    pipe = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", 
+        torch_dtype=torch.float16, 
+        variant="fp16", 
+        use_safetensors=True,
+        vae=vae
+    ).to("cuda")
+
+    refiner = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-refiner-1.0",
+        text_encoder_2=pipe.text_encoder_2,
+        vae=vae,
+        torch_dtype=torch.float16,
+        use_safetensors=True,
+        variant="fp16",
+    ).to("cuda")
+
+    return pipe, refiner
+
+app = App(
+        name="t2i-sdxl",
+        runtime=Runtime(
+            cpu=2,
+            memory="16Gi",
+            gpu="A10G",
+            image=Image(
+                python_version="python3.8",
+                python_packages=[
+                    "diffusers[torch]>=0.10",
+                    "transformers",
+                    "torch",
+                    "pillow",
+                    "accelerate",
+                    "safetensors",
+                    "xformers",
+                    "accelerate"
+                ],
+            ),
+        ),
+        volumes=[
+            Volume(name="models", path="./models"),
+            Volume(name="loras", path="./loras")
+        ],
+    )
+
+@app.task_queue(
+    loader=load_models,
+    outputs=[Output(path="output.png")],
+    keep_warm_seconds=60,
+)
+def generate_image(**inputs):
+    # Grab inputs passed to the API
+    prompt = inputs["prompt"]
+    cleaned_string, extracted_data = extract_tokens(prompt)
+
+    # Grab inputs passed to the API
+    negative_prompt = inputs.get("negative_prompt", "")
+    height = int(inputs.get("height", "1024"))
+    width = int(inputs.get("width", "1024"))
+    steps = int(inputs.get("steps", "50"))
+    scale = float(inputs.get("guidance_scale", "7.5"))
+    use_refiner = bool(inputs.get("use_refiner", "true"))
+    
+    # Retrieve pre-loaded model from loader
+    pipe, refiner = inputs["context"]
+
+    lora_names = handle_loras(extracted_data=extracted_data, pipe=pipe)
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    with torch.inference_mode():
+        with torch.autocast("cuda"):
+            if use_refiner:
+                image = pipe(
+                    prompt=cleaned_string, 
+                    num_inference_steps=steps, 
+                    negative_prompt=negative_prompt,
+                    guidance_scale=scale,
+                    height=height,
+                    width=width,
+                    denoising_end=0.8,
+                    output_type="latent",
+                ).images
+                image = refiner(
+                    prompt=cleaned_string,
+                    num_inference_steps=steps,
+                    negative_prompt=negative_prompt,
+                    guidance_scale=scale,
+                    height=height,
+                    width=width,
+                    denoising_start=0.8,
+                    image=image,
+                ).images[0]
+            else:
+                image = pipe(
+                    prompt=cleaned_string, 
+                    num_inference_steps=steps, 
+                    guidance_scale=scale,
+                    negative_prompt=negative_prompt,
+                    height=height,
+                    width=width
+                ).images[0]
+
+    unload_loras(lora_names, pipe)
+
+    print(f"Saved Image: {image}")
+    image.save("output.png")

--- a/api/beam/txt2vid/animatediff-xl.py
+++ b/api/beam/txt2vid/animatediff-xl.py
@@ -1,0 +1,109 @@
+"""
+### Animate diff XL text to video on Beam ###
+
+**Deploy it as an API**
+
+beam deploy animatediff-xl.py:generate_video
+"""
+from beam import App, Output, Volume, Runtime, Image
+import torch
+from diffusers import AnimateDiffSDXLPipeline, DDIMScheduler
+from diffusers.models import MotionAdapter
+from diffusers.utils import export_to_gif
+from common import extract_tokens, handle_loras, unload_loras
+
+cache_path = "./models"
+model_id = "stabilityai/stable-diffusion-xl-base-1.0"
+
+def load_models():
+    adapter = MotionAdapter.from_pretrained(
+        "guoyww/animatediff-motion-adapter-sdxl-beta", 
+        torch_dtype=torch.float16)
+    scheduler = DDIMScheduler.from_pretrained(
+        model_id,
+        subfolder="scheduler",
+        clip_sample=False,
+        timestep_spacing="linspace",
+        beta_schedule="linear",
+        steps_offset=1,
+    )
+    pipe = AnimateDiffSDXLPipeline.from_pretrained(
+        model_id,
+        motion_adapter=adapter,
+        torch_dtype=torch.float16,
+        variant="fp16",
+        cache_dir=cache_path,
+        use_safetensors=True,
+        scheduler=scheduler
+    ).to("cuda")
+
+    return pipe
+
+app = App(
+        name="t2v-animatediff-xl",
+        runtime=Runtime(
+            cpu=2,
+            memory="32Gi",
+            gpu="A10G",
+            image=Image(
+                python_version="python3.8",
+                python_packages=[
+                    "diffusers[torch]>=0.10",
+                    "transformers",
+                    "torch",
+                    "pillow",
+                    "accelerate",
+                    "safetensors",
+                    "xformers",
+                    "opencv-python",
+                    "peft",
+                ],
+            ),
+        ),
+        volumes=[
+            Volume(name="models", path="./models"),
+            Volume(name="loras", path="./loras"),
+        ],
+    )
+
+@app.task_queue(
+    loader=load_models,
+    outputs=[Output(path="output.gif")],
+    keep_warm_seconds=60,
+)
+def generate_video(**inputs):
+    # Grab inputs passed to the API
+    prompt = inputs["prompt"]
+    cleaned_string, extracted_data = extract_tokens(prompt)
+
+    # Grab inputs passed to the API
+    negative_prompt = inputs.get("negative_prompt", "")
+    height = int(inputs.get("height", "1024"))
+    width = int(inputs.get("width", "1024"))
+    steps = int(inputs.get("steps", "20"))
+    scale = float(inputs.get("guidance_scale", "8"))
+
+    # Retrieve pre-loaded model from loader
+    pipe = inputs["context"]
+
+    lora_names = handle_loras(extracted_data=extracted_data, pipe=pipe)
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    generator = torch.manual_seed(42)
+
+    with torch.inference_mode():
+        with torch.autocast("cuda"):
+            frames = pipe(
+                cleaned_string, 
+                negative_prompt=negative_prompt,
+                num_frames=16,
+                guidance_scale=scale,
+                num_inference_steps=steps, 
+                height=height,
+                width=width,
+                generator=generator,
+            ).frames[0]
+
+    unload_loras(lora_names, pipe)
+
+    export_to_gif(frames, "output.gif")

--- a/api/beam/txt2vid/animatediff.py
+++ b/api/beam/txt2vid/animatediff.py
@@ -1,0 +1,106 @@
+"""
+### I2VGen-XL image to video on Beam ###
+
+**Deploy it as an API**
+
+beam deploy animatediff.py:generate_video
+"""
+from beam import App, Output, Volume, Runtime, Image
+import torch
+from diffusers import AnimateDiffPipeline, DDIMScheduler, MotionAdapter
+from diffusers.utils import export_to_gif
+from common import extract_tokens, handle_loras, unload_loras
+
+cache_path = "./models"
+
+def load_models():
+    adapter = MotionAdapter.from_pretrained(
+        "guoyww/animatediff-motion-adapter-v1-5-2", 
+        torch_dtype=torch.float16)
+    scheduler = DDIMScheduler.from_pretrained(
+        "emilianJR/epiCRealism",
+        subfolder="scheduler",
+        clip_sample=False,
+        timestep_spacing="linspace",
+        beta_schedule="linear",
+        steps_offset=1,
+    )
+    pipe = AnimateDiffPipeline.from_pretrained(
+        "emilianJR/epiCRealism",
+        motion_adapter=adapter,
+        torch_dtype=torch.float16,
+        cache_dir=cache_path,
+        use_safetensors=True,
+        scheduler=scheduler
+    ).to("cuda")
+
+    return pipe
+
+app = App(
+        name="t2v-animatediff",
+        runtime=Runtime(
+            cpu=2,
+            memory="16Gi",
+            gpu="A10G",
+            image=Image(
+                python_version="python3.8",
+                python_packages=[
+                    "diffusers[torch]>=0.10",
+                    "transformers",
+                    "torch",
+                    "pillow",
+                    "accelerate",
+                    "safetensors",
+                    "xformers",
+                    "opencv-python",
+                    "peft",
+                ],
+            ),
+        ),
+        volumes=[
+            Volume(name="models", path="./models"),
+            Volume(name="loras", path="./loras"),
+        ],
+    )
+
+@app.task_queue(
+    loader=load_models,
+    outputs=[Output(path="output.gif")],
+    keep_warm_seconds=60,
+)
+def generate_video(**inputs):
+    # Grab inputs passed to the API
+    prompt = inputs["prompt"]
+    cleaned_string, extracted_data = extract_tokens(prompt)
+
+    # Grab inputs passed to the API
+    negative_prompt = inputs.get("negative_prompt", "")
+    height = int(inputs.get("height", "768"))
+    width = int(inputs.get("width", "768"))
+    steps = int(inputs.get("steps", "50"))
+    scale = float(inputs.get("guidance_scale", "7.5"))
+
+    # Retrieve pre-loaded model from loader
+    pipe = inputs["context"]
+
+    lora_names = handle_loras(extracted_data=extracted_data, pipe=pipe)
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    generator = torch.manual_seed(42)
+
+    with torch.inference_mode():
+        with torch.autocast("cuda"):
+            frames = pipe(
+                cleaned_string, 
+                negative_prompt=negative_prompt,
+                num_frames=16,
+                guidance_scale=scale,
+                num_inference_steps=steps, 
+                height=height,
+                width=width,
+                generator=generator,
+            ).frames[0]
+
+    unload_loras(lora_names, pipe)
+
+    export_to_gif(frames, "output.gif")

--- a/api/beam/txt2vid/common.py
+++ b/api/beam/txt2vid/common.py
@@ -1,0 +1,29 @@
+import re
+
+def extract_tokens(input_string):
+    tokens = re.findall(r'<lora:([^:]+):([0-9.]+)>', input_string)
+    print(f"Found {len(tokens)} tokens")
+    cleaned_string = re.sub(r'<lora:[^>]+>', '', input_string)
+    extracted_data = [{'name': token[0], 'scale': float(token[1])} for token in tokens]
+    return cleaned_string, extracted_data
+
+def handle_loras(extracted_data, pipe):
+    lora_names = []
+    if extracted_data:
+        lora_scales = []
+        for token in extracted_data:
+            lora_name = token['name']
+            print(f"Found lora with name {lora_name}")
+            lora_scale = token['scale']
+            pipe.load_lora_weights(
+                "./loras", 
+                weight_name=f"{lora_name}.safetensors", 
+                adapter_name=lora_name)
+            lora_names.append(lora_name)
+            lora_scales.append(lora_scale)
+        pipe.set_adapters(lora_names, lora_scales)
+    return lora_names
+
+def unload_loras(lora_names, pipe):
+    if lora_names:
+        pipe.delete_adapters(lora_names)


### PR DESCRIPTION
# Background

As the platform utilizes Beam for cloud inference, we need to include some sample beam scripts for the most mainstream models.

# Solution

Add beam python scripts to work with Stable Diffusion models.

# Main changes

- Add python scripts for txt2img
- Add python scripts for txt2vid
- Add python scripts for img2img

# Additional changes

- None

# Readyness checks

- [x] Code is clean
- [x] No commented code
- [x] Test cases added if required
- [x] Passing build

Closes #36 