### PR TITLE
Update github action for creating the github release

### DIFF
--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -99,10 +99,11 @@ jobs:
         git push origin develop
 
     - name: Create GitHub Release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: v${{ steps.bump-version.outputs.new_version }}
         release_name: Release v${{ steps.bump-version.outputs.new_version }}
-        body-path: changelog.txt
+        body_path: changelog.txt
+        generate_release_notes: true


### PR DESCRIPTION
# Background

Current workflow for performing a release uses an outdated and archived action for generating the GitHub release.

# Solution

Update the action to [softprops/action-gh-release](https://github.com/softprops/action-gh-release)

# Main changes

- Update workflow yml file

# Additional changes

None

# Readyness checks

- [x] Code is clean
- [x] No commented code
- [x] Test cases added if required
- [x] Passing build

Closes #49 