### PR TITLE
Add version and build date to footer

### DIFF
--- a/ui/scripts/getGitInfo.js
+++ b/ui/scripts/getGitInfo.js
@@ -16,8 +16,10 @@ const getGitInfo = (command, defaultValue) => {
 };
 
 // Get branch and commit ID or use defaults
-const branch = getGitInfo('git rev-parse --abbrev-ref HEAD', 'unknown');
-const commitId = getGitInfo('git rev-parse HEAD', 'unknown');
+const branch = getGitInfo('git rev-parse --abbrev-ref HEAD', 
+  process.env.HEROKU_APP_NAME || 'feature branch');
+const commitId = getGitInfo('git rev-parse HEAD', 
+  process.env.SOURCE_VERSION || 'unknown');
 
 // Read version from package.json
 const packageJsonPath = path.resolve(__dirname, '../package.json');

--- a/ui/scripts/getGitInfo.js
+++ b/ui/scripts/getGitInfo.js
@@ -2,6 +2,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+// Path to gitInfo.json
 const gitInfoPath = path.resolve(__dirname, '../gitInfo.json');
 
 // Function to execute a git command and return the result, or default if it fails
@@ -15,10 +16,16 @@ const getGitInfo = (command, defaultValue) => {
 };
 
 // Get branch and commit ID or use defaults
-const branch = getGitInfo('git rev-parse --abbrev-ref HEAD', 
-    process.env.HEROKU_APP_NAME || 'feature branch');
-const commitId = getGitInfo('git rev-parse HEAD', 
-    process.env.SOURCE_VERSION || 'unknown');
+const branch = getGitInfo('git rev-parse --abbrev-ref HEAD', 'unknown');
+const commitId = getGitInfo('git rev-parse HEAD', 'unknown');
 
-// Write the git info to a file
-fs.writeFileSync(gitInfoPath, JSON.stringify({ branch, commitId }));
+// Read version from package.json
+const packageJsonPath = path.resolve(__dirname, '../package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const version = packageJson.version || 'unknown';
+
+// Get the current date as the build date
+const buildDate = new Date().toISOString();
+
+// Write the git info, version, and build date to a file
+fs.writeFileSync(gitInfoPath, JSON.stringify({ branch, commitId, version, buildDate }));

--- a/ui/src/components/Footer.css
+++ b/ui/src/components/Footer.css
@@ -1,0 +1,24 @@
+.footer.collapsed {
+    height: 40px;
+    /* Adjust as necessary for the button height */
+    overflow: hidden;
+    transition: height 0.3s ease;
+}
+
+.footer {
+    transition: height 0.3s ease;
+}
+
+.footer button {
+    width: 100%;
+}
+
+.footer .bi {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    background-color: #fff;
+    border: none;
+    border-radius: 50%;
+    padding: 5px;
+}

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -1,16 +1,32 @@
-import React from 'react';
-import { Container, Row, Col } from 'react-bootstrap';
+import React, { useState } from 'react';
+import { Container, Row, Col, Button } from 'react-bootstrap';
+import './Footer.css';
 
 const Footer: React.FC = () => {
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
+  const toggleCollapse = () => {
+    setIsCollapsed(!isCollapsed);
+  };
+
   return (
-    <footer className="footer mt-auto py-3 bg-light">
+    <footer className={`footer mt-auto py-3 bg-light ${isCollapsed ? 'collapsed' : ''}`}>
       <Container>
         <Row>
           <Col className="text-center">
-            <p>
-              Build from branch: {process.env.BRANCH} <br />
-              Commit ID: {process.env.COMMIT_ID}
-            </p>
+            <Button variant="link" onClick={toggleCollapse} aria-label="Toggle footer" aria-expanded={!isCollapsed}>
+              <i className={`bi ${isCollapsed ? 'bi-chevron-up' : 'bi-chevron-down'}`}></i>
+            </Button>
+            {!isCollapsed && (
+              <div>
+                <p>
+                  Version: {process.env.VERSION} <br />
+                  Build Date: {process.env.BUILD_DATE} <br />
+                  Build from branch: {process.env.BRANCH} <br />
+                  Commit ID: {process.env.COMMIT_ID}
+                </p>
+              </div>
+            )}
           </Col>
         </Row>
       </Container>

--- a/ui/test/components/Footer.test.tsx
+++ b/ui/test/components/Footer.test.tsx
@@ -1,18 +1,28 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import Footer from '../../src/components/Footer';
 
 // Mock the environment variables
 process.env.BRANCH = 'main';
 process.env.COMMIT_ID = 'abc123';
+process.env.VERSION = '1.0.0';
+process.env.BUILD_DATE = '2024-07-19T00:00:00Z';
 
-describe('Footer', () => {
-    test('renders footer with branch and commit ID', () => {
-    const { getByText } = render(<Footer />);
+test('renders footer and toggles visibility', () => {
+  const { getByText, queryByText, getByRole } = render(<Footer />);
+  const button = getByRole('button', { name: 'Toggle footer' });
 
-    // Assert that the branch is rendered correctly
-    expect(getByText(/Build from branch: main/i)).toBeInTheDocument();
-    // Assert that the commit ID is rendered correctly
-    expect(getByText(/Commit ID: abc123/i)).toBeInTheDocument();
-    });
+  // Initially, the footer content should not be visible
+  expect(queryByText(/Build from branch: main/i)).not.toBeInTheDocument();
+
+  // Click the toggle button to show the footer content
+  fireEvent.click(button);
+  expect(getByText(/Build from branch: main/i)).toBeInTheDocument();
+  expect(getByText(/Commit ID: abc123/i)).toBeInTheDocument();
+  expect(getByText(/Version: 1.0.0/i)).toBeInTheDocument();
+  expect(getByText(/Build Date: 2024-07-19T00:00:00Z/i)).toBeInTheDocument();
+
+  // Click the toggle button again to hide the footer content
+  fireEvent.click(button);
+  expect(queryByText(/Build from branch: main/i)).not.toBeInTheDocument();
 });

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -41,6 +41,8 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env.BRANCH': JSON.stringify(gitInfo.branch),
       'process.env.COMMIT_ID': JSON.stringify(gitInfo.commitId),
+      'process.env.VERSION': JSON.stringify(gitInfo.version),
+      'process.env.BUILD_DATE': JSON.stringify(gitInfo.buildDate),
     }),
   ],
   devServer: {


### PR DESCRIPTION
# Background

Footer contains branch and commit ID, but no version, nor build date.

# Solution

Add version and build date to footer.

# Main changes

- Update footer component to show version and build date from environment variables
- Update getGitInfo to retrieve version and build date
- Update web pack config to pass the version and build date to environment variables

# Additional changes

- Make footer collapsible
- Update tests

# Readyness checks

- [x] Code is clean
- [x] No commented code
- [x] Test cases added if required
- [x] Passing build

Closes #51 